### PR TITLE
feat: add CNAME records for Gateway API objects

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -622,6 +622,30 @@ func checkIngressTargetAnnotation(annotation string, ingress *networking.Ingress
 	return "", false
 }
 
+func checkHTTPRouteTargetAnnotation(annotation string, httpRoute *gatewayapi_v1.HTTPRoute) (string, bool) {
+	if annotationValue, exists := httpRoute.Annotations[annotation]; exists {
+		if dns.IsFqdn(annotationValue) {
+			return strings.ToLower(annotationValue), true
+		} else {
+			log.Infof("Invalid FQDN: %s", annotationValue)
+		}
+	}
+
+	return "", false
+}
+
+func checkGRPCRouteTargetAnnotation(annotation string, grpcRoute *gatewayapi_v1.GRPCRoute) (string, bool) {
+	if annotationValue, exists := grpcRoute.Annotations[annotation]; exists {
+		if dns.IsFqdn(annotationValue) {
+			return strings.ToLower(annotationValue), true
+		} else {
+			log.Infof("Invalid FQDN: %s", annotationValue)
+		}
+	}
+
+	return "", false
+}
+
 func virtualServerHostnameIndexFunc(obj interface{}) ([]string, error) {
 	virtualServer, ok := obj.(*nginx_v1.VirtualServer)
 	if !ok {
@@ -741,6 +765,14 @@ func lookupHttpRouteIndex(http, gw cache.SharedIndexInformer) func([]string) []i
 
 		for _, obj := range objs {
 			httpRoute, _ := obj.(*gatewayapi_v1.HTTPRoute)
+
+			// Check if we should return a CNAME record
+			if annotation, exists := checkHTTPRouteTargetAnnotation(targetAnnotationKey, httpRoute); exists {
+				result = append(result, annotation)
+				// in case target is defined, ignoring other fields completely
+				return
+			}
+
 			result = append(
 				result,
 				lookupGateways(gw, httpRoute.Spec.ParentRefs, httpRoute.Namespace)...)
@@ -805,6 +837,13 @@ func lookupGRPCRouteIndex(grpc, gw cache.SharedIndexInformer) func([]string) []i
 
 		for _, obj := range objs {
 			grpcRoute, _ := obj.(*gatewayapi_v1.GRPCRoute)
+
+			// Check if we should return a CNAME record
+			if annotation, exists := checkGRPCRouteTargetAnnotation(targetAnnotationKey, grpcRoute); exists {
+				result = append(result, annotation)
+				// in case target is defined, ignoring other fields completely
+				return
+			}
 			result = append(
 				result,
 				lookupGateways(gw, grpcRoute.Spec.ParentRefs, grpcRoute.Namespace)...)

--- a/test/app/gateway-api.yaml
+++ b/test/app/gateway-api.yaml
@@ -48,7 +48,6 @@ spec:
       backendRefs:
         - name: backend
           port: 80
-
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -68,7 +67,6 @@ spec:
       backendRefs:
         - name: backend
           port: 80
-
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -108,6 +106,18 @@ spec:
         - name: backend
           port: 80
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: myservice-cname
+  namespace: default
+  annotations:
+    coredns.io/target: redirect.here.
+spec:
+  parentRefs:
+    - name: gateway-one
+  hostnames: ["myservice-cname.gw.foo.org"]
+---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
@@ -135,6 +145,18 @@ spec:
     - backendRefs:
         - name: backend
           port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: myservicegrpc-cname
+  namespace: default
+  annotations:
+    coredns.io/target: redirect.here.
+spec:
+  parentRefs:
+    - name: gateway-one
+  hostnames: ["myservicegrpc-cname.gw.foo.org"]
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/test/test-kind-dns.sh
+++ b/test/test-kind-dns.sh
@@ -26,8 +26,10 @@ myservicea.gw true
 myserviceb.gw true
 myservicec.gw-wrong false
 myserviced.gw true
+myservice-cname.gw true
 myservicetls.gw true
 myservicegrpc.gw true
+myservicegrpc-cname.gw true
 *.http-wildcard.gw true
 asdf.http-wildcard.gw true
 *.tls-wildcard.gw true


### PR DESCRIPTION
Only supports HTTPRoute and GRPCRoute.
Technically GRPCRoute is not needed since it doesn't make much sense for a CNAME record.